### PR TITLE
Google tag manager

### DIFF
--- a/config/docusaurus.config.js
+++ b/config/docusaurus.config.js
@@ -75,6 +75,9 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        googleTagManager: {
+          containerId: 'GTM-T4SWD2V'
+        },
       }),
     ],
     [

--- a/config/docusaurus.config.js.new
+++ b/config/docusaurus.config.js.new
@@ -75,6 +75,9 @@ const config = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        googleTagManager: {
+          containerId: 'GTM-T4SWD2V'
+        },
       }),
     ],
     [


### PR DESCRIPTION
This adds configuration for google tag manager as per the docs: 
https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-tag-manager