### PR TITLE
Basic Fixes for i18n locales

### DIFF
--- a/config/docusaurus.config.js
+++ b/config/docusaurus.config.js
@@ -27,7 +27,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],  //devrel#192: remove non-english locales  -prev: locales: ['en', 'zh', 'ko'],
+    locales: ['en', 'zh', 'ko'],
     path: 'i18n',
     localeConfigs: {
       en: {

--- a/config/docusaurus.config.js
+++ b/config/docusaurus.config.js
@@ -25,6 +25,7 @@ const config = {
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want
   // to replace "en" with "zh-Hans".
+  // --> NOTE: Update src/theme/TOC/index.js to match defaultLocal and locales <--
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'zh', 'ko'],

--- a/config/docusaurus.config.js.new
+++ b/config/docusaurus.config.js.new
@@ -27,7 +27,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale: 'en',
-    locales: ['en'],  //devrel#192: remove non-english locales  -prev: locales: ['en', 'zh', 'ko'],
+    locales: ['en', 'zh', 'ko'],
     path: 'i18n',
     localeConfigs: {
       en: {

--- a/web/docusaurus/src/components/CustomTOC/CustomTOC.tsx
+++ b/web/docusaurus/src/components/CustomTOC/CustomTOC.tsx
@@ -39,7 +39,20 @@ function useDocsSearchVersionsHelpers() {
 
 const getPathKey = (path) => {
   const pathParts = path.split('/');
+  // look at first directory in URL
+  // simple check for locals 'en' 'zh' 'ko' are length 2
+  // better solution loop through array config.i18n.locales looking for match
+  if (pathParts[1].length == 2) {
+    return {
+      localKey: pathParts[1],
+      pluginId: pathParts[2],
+      version: pathParts[3],
+    }
+  }
+  // default is english 'en'
+  // better solution use config.i18n.defaultLocale
   return {
+    localKey: 'en',
     pluginId: pathParts[1],
     version: pathParts[2],
   }
@@ -66,10 +79,10 @@ export default function CustomTOC({ doc, onClick }) {
 
   useEffect(() => {
     Object.keys(allDocsData).forEach((key) => {
-      const { pluginId } = getPathKey(pathname);
+      const { localKey, pluginId } = getPathKey(pathname);
       const currentDoc = allDocsData[pluginId === 'docs' ? 'default' : pluginId.toLowerCase()];
       const { versions } = currentDoc;
-  
+
       if (versions) {
         const versionOptions = versions.map((version) => ({
           value: version.name,
@@ -87,9 +100,15 @@ export default function CustomTOC({ doc, onClick }) {
 
   const handleOnChange = (selectedOption) => {
     const { path } = selectedOption;
-    const { pluginId, version } = getPathKey(pathname);
-    const newPath = pathname.replace(`/${pluginId}/${version}`, path);
-    
+    const { localKey, pluginId, version } = getPathKey(pathname);
+    let newPath = undefined;
+    // english is default
+    if (localKey === 'en') {
+      newPath = pathname.replace(`/${pluginId}/${version}`, path);
+    } else {
+      newPath = pathname.replace(`/${localKey}/${pluginId}/${version}`, path);
+    }
+
     if (newPath === pathname) {
       return;
     }

--- a/web/docusaurus/src/components/CustomTOC/CustomTOC.tsx
+++ b/web/docusaurus/src/components/CustomTOC/CustomTOC.tsx
@@ -106,11 +106,9 @@ export default function CustomTOC({ doc, onClick }) {
     const {siteConfig} = useDocusaurusContext();
     const { path } = selectedOption;
     const { localKey, pluginId, version } = getPathKey(pathname);
-    let newPath = undefined;
+    let newPath = pathname.replace(`/${pluginId}/${version}`, path);
     // english is default
-    if (localKey === siteConfig.i18n.defaultLocale) {
-      newPath = pathname.replace(`/${pluginId}/${version}`, path);
-    } else {
+    if (localKey !== siteConfig.i18n.defaultLocale) {
       newPath = pathname.replace(`/${localKey}/${pluginId}/${version}`, path);
     }
 

--- a/web/docusaurus/src/components/CustomTOC/CustomTOC.tsx
+++ b/web/docusaurus/src/components/CustomTOC/CustomTOC.tsx
@@ -5,6 +5,7 @@ import { useAllDocsData } from '@docusaurus/plugin-content-docs/client';
 import TOCItems from '@theme/TOCItems';
 import styles from './styles.module.css';
 import { useLocation, useHistory } from '@docusaurus/router';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 // Using a custom className
 // This prevents TOCInline/TOCCollapsible getting highlighted by mistake
 
@@ -38,21 +39,23 @@ function useDocsSearchVersionsHelpers() {
 }
 
 const getPathKey = (path) => {
+  // grab main docusarus configuration
+  const {siteConfig} = useDocusaurusContext();
   const pathParts = path.split('/');
   // look at first directory in URL
-  // simple check for locals 'en' 'zh' 'ko' are length 2
-  // better solution loop through array config.i18n.locales looking for match
-  if (pathParts[1].length == 2) {
+  // simple check for locales matching config entry 'en' 'zh' 'ko'
+  const localeFromUrl = siteConfig.i18n.locales.find(locale => locale === pathParts[1])
+  if (localeFromUrl) {
     return {
       localKey: pathParts[1],
       pluginId: pathParts[2],
       version: pathParts[3],
     }
   }
-  // default is english 'en'
-  // better solution use config.i18n.defaultLocale
+  // undefined localeFromURL
+  // get default from config
   return {
-    localKey: 'en',
+    localKey: siteConfig.i18n.defaultLocale,
     pluginId: pathParts[1],
     version: pathParts[2],
   }
@@ -99,11 +102,13 @@ export default function CustomTOC({ doc, onClick }) {
   }, [allDocsData, pathname]);
 
   const handleOnChange = (selectedOption) => {
+    // grab main docusarus configuration
+    const {siteConfig} = useDocusaurusContext();
     const { path } = selectedOption;
     const { localKey, pluginId, version } = getPathKey(pathname);
     let newPath = undefined;
     // english is default
-    if (localKey === 'en') {
+    if (localKey === siteConfig.i18n.defaultLocale) {
       newPath = pathname.replace(`/${pluginId}/${version}`, path);
     } else {
       newPath = pathname.replace(`/${localKey}/${pluginId}/${version}`, path);

--- a/web/docusaurus/src/theme/TOC/index.js
+++ b/web/docusaurus/src/theme/TOC/index.js
@@ -38,21 +38,24 @@ function useDocsSearchVersionsHelpers() {
 }
 
 const getPathKey = (path) => {
+  // duplicate what is in config, react can't access docusarus config from here
+  // this must match docusaurus.config.js
+  const i18n = { locales: ['en', 'zh', 'ko'], defaultLocale: 'en' }
   const pathParts = path.split('/');
   // look at first directory in URL
-  // simple check for locals 'en' 'zh' 'ko' are length 2
-  // better solution loop through array config.i18n.locales looking for match
-  if (pathParts[1].length == 2) {
+  // simple check for locales matching config entry 'en' 'zh' 'ko'
+  const localeFromUrl = i18n.locales.find(locale => locale === pathParts[1])
+  if (localeFromUrl) {
     return {
       localKey: pathParts[1],
       pluginId: pathParts[2],
       version: pathParts[3],
     }
   }
-  // default is english 'en'
-  // better solution use config.i18n.defaultLocale
+  // undefined localeFromURL
+  // get default from config
   return {
-    localKey: 'en',
+    localKey: i18n.defaultLocale,
     pluginId: pathParts[1],
     version: pathParts[2],
   }

--- a/web/docusaurus/src/theme/TOC/index.js
+++ b/web/docusaurus/src/theme/TOC/index.js
@@ -10,6 +10,10 @@ import { useLocation, useHistory } from '@docusaurus/router';
 // This prevents TOCInline/TOCCollapsible getting highlighted by mistake
 const suggestTitle = '<ENTER A TITLE HERE>';
 
+// duplicate what is in config, react can't access docusarus config from here
+// this must match docusaurus.config.js
+const i18n = { locales: ['en', 'zh', 'ko'], defaultLocale: 'en' }
+
 function useDocsSearchVersionsHelpers() {
   const allDocsData = useAllDocsData();
   // State of the version select menus / algolia facet filters
@@ -38,9 +42,6 @@ function useDocsSearchVersionsHelpers() {
 }
 
 const getPathKey = (path) => {
-  // duplicate what is in config, react can't access docusarus config from here
-  // this must match docusaurus.config.js
-  const i18n = { locales: ['en', 'zh', 'ko'], defaultLocale: 'en' }
   const pathParts = path.split('/');
   // look at first directory in URL
   // simple check for locales matching config entry 'en' 'zh' 'ko'
@@ -105,10 +106,8 @@ export default function TOC({className, ...props}) {
   const handleOnChange = (selectedOption) => {
     const { path } = selectedOption;
     const { localKey, pluginId, version } = getPathKey(pathname);
-    let newPath = undefined;
-    if (localKey === 'en') {
-      newPath = pathname.replace(`/${pluginId}/${version}`, path);
-    } else {
+    let newPath = pathname.replace(`/${pluginId}/${version}`, path);
+    if (localKey !== i18n.defaultLocale ) {
       newPath = pathname.replace(`/${localKey}/${pluginId}/${version}`, path);
     }
 

--- a/web/docusaurus/src/theme/TOC/index.js
+++ b/web/docusaurus/src/theme/TOC/index.js
@@ -39,7 +39,20 @@ function useDocsSearchVersionsHelpers() {
 
 const getPathKey = (path) => {
   const pathParts = path.split('/');
+  // look at first directory in URL
+  // simple check for locals 'en' 'zh' 'ko' are length 2
+  // better solution loop through array config.i18n.locales looking for match
+  if (pathParts[1].length == 2) {
+    return {
+      localKey: pathParts[1],
+      pluginId: pathParts[2],
+      version: pathParts[3],
+    }
+  }
+  // default is english 'en'
+  // better solution use config.i18n.defaultLocale
   return {
+    localKey: 'en',
     pluginId: pathParts[1],
     version: pathParts[2],
   }
@@ -67,10 +80,10 @@ export default function TOC({className, ...props}) {
 
   useEffect(() => {
     Object.keys(allDocsData).forEach((key) => {
-      const { pluginId } = getPathKey(pathname);
+      const { localKey, pluginId } = getPathKey(pathname);
       const currentDoc = allDocsData[pluginId === 'docs' ? 'default' : pluginId.toLowerCase()];
       const { versions } = currentDoc;
-  
+
       if (versions) {
         const versionOptions = versions.map((version) => ({
           value: version.name,
@@ -88,9 +101,14 @@ export default function TOC({className, ...props}) {
 
   const handleOnChange = (selectedOption) => {
     const { path } = selectedOption;
-    const { pluginId, version } = getPathKey(pathname);
-    const newPath = pathname.replace(`/${pluginId}/${version}`, path);
-    
+    const { localKey, pluginId, version } = getPathKey(pathname);
+    let newPath = undefined;
+    if (localKey === 'en') {
+      newPath = pathname.replace(`/${pluginId}/${version}`, path);
+    } else {
+      newPath = pathname.replace(`/${localKey}/${pluginId}/${version}`, path);
+    }
+
     history.push(newPath);
   }
 


### PR DESCRIPTION
Fixes #110 
Gets the pages up and running again for non-en locals. 

To test follow software installation instructions 
https://github.com/eosnetworkfoundation/docsgen/blob/main/docs/FirstInstallSoftware.md
Then run these commands, this will take a while. 
```
mkdir -p ~/eosnetworkfoundation/build_root
./clean_rebuild.sh -d ~/eosnetworkfoundation/build_root
cd ~/eosnetworkfoundation/build_root/devdocs
npm run serve
```
Starts a server on localhost:3000. Browse around. Try adding a 'zh' or 'ko' to the front of the url. Example
http://localhost:3000/docs/latest/smart-contracts/tutorials/understanding-ABI-files
http://localhost:3000/zh/docs/latest/smart-contracts/tutorials/understanding-ABI-files
